### PR TITLE
fix: Replace scrollIntoView with scrollTo to fix chat scroll bug

### DIFF
--- a/src/features/chat/components/ChatRoom.tsx
+++ b/src/features/chat/components/ChatRoom.tsx
@@ -42,8 +42,11 @@ export function ChatRoom({ room, currentUserId }: ChatRoomProps) {
       loadingOlderRef.current = false;
       return;
     }
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    if (messagesContainerRef.current) {
+      messagesContainerRef.current.scrollTo({
+        top: messagesContainerRef.current.scrollHeight,
+        behavior: 'smooth'
+      });
     }
   }, [data]);
 


### PR DESCRIPTION
Fix scroll behavior in chat room to scroll within the chat container instead of the entire window. Previously, scrollIntoView would scroll the entire page to the bottom, making the chat area disappear.

Changes:
- Replace scrollIntoView() with explicit container scrollTo()
- Use scrollHeight to scroll to bottom of messages container
- Ensure scroll stays within chat area, not window level

Fixes issue where sending/receiving messages would scroll to site footer instead of staying within the chat window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 새 메시지 도착 시 채팅창 자동 스크롤이 더욱 부드럽고 자연스럽게 개선되었습니다. 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->